### PR TITLE
Added records count to models API response

### DIFF
--- a/app/api/v1/routes/model_routes.rb
+++ b/app/api/v1/routes/model_routes.rb
@@ -36,8 +36,9 @@ module Evercam
       models = models.where(Sequel.ilike(:name, "%#{params[:name]}%")) unless params.fetch(:name, nil).nil?
       models = models.where(exid: params[:id]) unless params.fetch(:id, nil).nil?
       total_pages = models.count / limit
+      count = models.count
       models = models.limit(limit, page*limit)
-      present(Array(models.all), with: Presenters::Model).merge!({ :pages => total_pages})
+      present(Array(models.all), with: Presenters::Model).merge!(pages: total_pages, records: count)
     end
 
     #---------------------------------------------------------------------------


### PR DESCRIPTION
@mosic: Added records (count) to GET /v1/models to improve the performance. If only total number of records are required then simply use response.records instead of response.models.count